### PR TITLE
Builders check-in counter

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -21,25 +21,10 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <style jsx>{`
-              @keyframes pulseScale {
-                0%,
-                100% {
-                  transform: scale(1);
-                }
-                50% {
-                  transform: scale(1.4);
-                }
-              }
-              .pulse-scale {
-                animation: pulseScale 2s ease-in-out infinite;
-              }
-            `}</style>
-
             {isLoading ? (
               <span className="loading loading-spinner loading-sm"></span>
             ) : (
-              <span className="inline-block pulse-scale">{checkedInCount}</span>
+              <span className="inline-block animate-pulse">{checkedInCount}</span>
             )}
           </p>
         </div>


### PR DESCRIPTION
## Description

The checked-in builders counter display is implemented on the homepage. Counter is a smooth inflating and deflating animation of the number of builders that have checked in to the contract.

### Screenshot

[Screencast from 20. 06. 2025 15:42:35.webm](https://github.com/user-attachments/assets/714a11bf-8a23-40f2-b2cd-8d2e507b2858)

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #5_

Your ENS/address: 0xdaC6E56F86Fb6f18c4114C2E4f41901ab9803096
